### PR TITLE
Order by post modified, Ascending

### DIFF
--- a/revisions-digest.php
+++ b/revisions-digest.php
@@ -179,6 +179,8 @@ function get_updated_posts( int $timeframe ) : array {
 			'after'  => $earliest,
 			'column' => 'post_modified',
 		],
+		'order_by' => 'post_modified',
+		'order'    => 'ASC',
 	] );
 
 	// @TODO this might prime the post cache


### PR DESCRIPTION
This puts the most recent revisions at the top of the list (instead of sorting by the publication dates of the modified posts)